### PR TITLE
Update external link fieldtype

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^1.0",
         "guzzlehttp/guzzle": "^6.3",
-        "jonassiewertsen/link-fieldtype": "^1.0",
+        "jonassiewertsen/statamic-external-link": "^1.1",
         "laravel/framework": "^7.0",
         "laravel/tinker": "^2.0",
         "spatie/statamic-responsive-images": "^1.2",


### PR DESCRIPTION
I had to rename this addon to avoid conflicts with the core 'link' addon, which did not exist when I first created this addon. 

I hope it does help